### PR TITLE
Add sentence to clarify that architecture issues should not be driven by frontend bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Context
 
-The issue motivating this decision, and any context that influences or constrains the decision.
+The issue motivating this decision, and any context that influences or constrains the decision. Your motivation cannot include that the frontend is not representing the data correctly, as that is a frontend issue.
 
 ## Proposal
 


### PR DESCRIPTION
We should never change the architecture of the backend because of bugs in the frontend. This PR adds a line to the issue template to point people at opening frontend issues instead.