### PR TITLE
Update ADR-0005, add isort

### DIFF
--- a/adr/0005-code-formatting.md
+++ b/adr/0005-code-formatting.md
@@ -22,9 +22,9 @@ base. In place, a codebase with such formatting is:
 - We use [Black](https://github.com/python/black) as code formatter for the back-end codebase.
 - We use Black's default options.
 - We CI to ensure PRs are appropriately formatted before being accepted.
-- We recommend and document the setup of `Black`, `pylint`, and `flake8` in the development environment.
+- We recommend and document the setup of `Black`, `pylint`, `flake8`, and `isort` in the development environment.
 
 ## Consequences
 
 - We retain Flake8, but set `max-line-length = 88` and `ignore = E501, W503, E203` to `setup.cfg`.
-- We retain pylint, but disable all formatting checks.
+- We retain pylint, but disable all formatting checks and `wrong-import-order`. The import order it handled by `isort`.

--- a/adr/0005-code-formatting.md
+++ b/adr/0005-code-formatting.md
@@ -27,4 +27,4 @@ base. In place, a codebase with such formatting is:
 ## Consequences
 
 - We retain Flake8, but set `max-line-length = 88` and `ignore = E501, W503, E203` to `setup.cfg`.
-- We retain pylint, but disable all formatting checks and `wrong-import-order`. The import order it handled by `isort`.
+- We retain pylint, but disable all formatting checks and `wrong-import-order`. The import order is handled by `isort`.


### PR DESCRIPTION
In home-assistant/home-assistant#29739, we have added `isort` to both our CI and to the pre-commit hooks.

This PR updates ADR-0005 to reflect that.