### PR TITLE
ADR-0011 - Discovery Requires Unique ID

### DIFF
--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -8,27 +8,39 @@ Accepted
 
 ## Context
 
-There is a mechanism to ignore discovered config flows using unique ids attached to config flow but not all integrations may set a unique id due to lack of truly unique identifiers or just not having been updated for concerns of backwards compatibility.
+There is a mechanism to ignore discovered config flows using unique ids attached to config flow
+but not all integrations may set a unique id due to lack of truly unique identifiers
+or just not having been updated for concerns of backwards compatibility.
 
-This creates an UX issue that has started to become more pronounced with more config flows being added every release (which is awesome!). The real issue is not all discovery processes are created equal and that becomes an issue for consistency.
+This creates an UX issue that has started to become more pronounced with more config flows
+being added every release (which is awesome!). The real issue is not all discovery processes 
+are created equal and that becomes an issue for consistency.
 
 ## Proposal
 
-All future integratons with discoverable config flows should be required to set an unique id during discovery.
+All future integratons with discoverable config flows should be required to set an
+unique id during discovery.
 
-All existing integrations should be reviewed for possible ways to improve identification during discovery config flow. A whitelist could be developed to allow existing integrations to remain functional under new requirements.
+All existing integrations should be reviewed for possible ways to improve identification
+during discovery config flow. A whitelist could be developed to allow existing integrations
+to remain functional under new requirements.
 
-If a unique id can sometimes not be available such as older devices lack identifiers in zeroconf/ssdp/etc then the device should be prevented from being shown to user.
+If a unique id can sometimes not be available such as older devices lack identifiers in 
+zeroconf/ssdp/etc then the device should be prevented from being shown to user.
 
 ## Decision
 
 To protect project goals and to provide clarity to our users and contributors,
-we’re introducing the following rules on how discoverable integrations need to be configured:
+we're introducing the following rules on how discoverable integrations need to be configured:
 
-- Integrations that are discoverable must provide an unique id (via `async_set_unique_id`) to allow the user to ignore the discovered config entry.
+- Integrations that are discoverable must provide an unique id (via `async_set_unique_id`) 
+to allow the user to ignore the discovered config entry.
 
-These rules apply to all new integrations. Existing integrations should be reviewed for possible ways to improve identification during discovery.
+These rules apply to all new integrations. Existing integrations should be reviewed 
+for possible ways to improve identification during discovery.
 
 ## Consequences
 
-Discovery UX improves at the expense of some unidentifiable or non-conforming devices requiring manual setup.
+- Removes confusion and questions around the ability to ignore unwanted discoveries
+  for all users.
+- This might impact the number of integrations that are able to be discovered.

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -1,4 +1,4 @@
-# 0010. Discovery Requires Unique ID
+# 0011. Discovery Requires Unique ID
 
 Date: 2020-04-27
 
@@ -8,7 +8,7 @@ Accepted
 
 ## Context
 
-There is a mechnism to ignore discovered config flows using unique ids attached to config flow but not all integrations may set a unique id due to lack of truly unique identifiers or just not having been updated for concerns of backwards compatibility.
+There is a mechanism to ignore discovered config flows using unique ids attached to config flow but not all integrations may set a unique id due to lack of truly unique identifiers or just not having been updated for concerns of backwards compatibility.
 
 This creates an UX issue that has started to become more pronounced with more config flows being added every release (which is awesome!). The real issue is not all discovery processes are created equal and that becomes an issue for consistency.
 

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -31,7 +31,7 @@ in zeroconf/ssdp/api/etc then the config entry should not be shown to user.
 ## Decision
 
 To protect project goals and to provide clarity to our users and contributors,
-we're introducing the following rules on how discoverable integrations need to be configured:
+we're introducing the following rules on how discoverable integrations need to be designed:
 
 - Integrations that are discoverable must provide an unique id (via `async_set_unique_id`) 
 to allow the user to ignore the discovered config entry.

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -1,0 +1,34 @@
+# 0010. Discovery Requires Unique ID
+
+Date: 2020-04-27
+
+## Status
+
+Accepted
+
+## Context
+
+There is a mechnism to ignore discovered config flows using unique ids attached to config flow but not all integrations may set a unique id due to lack of truly unique identifiers or just not having been updated for concerns of backwards compatibility.
+
+This creates an UX issue that has started to become more pronounced with more config flows being added every release (which is awesome!). The real issue is not all discovery processes are created equal and that becomes an issue for consistency.
+
+## Proposal
+
+All future integratons with discoverable config flows should be required to set an unique id during discovery.
+
+All existing integrations should be reviewed for possible ways to improve identification during discovery config flow. A whitelist could be developed to allow existing integrations to remain functional under new requirements.
+
+If a unique id can sometimes not be available such as older devices lack identifiers in zeroconf/ssdp/etc then the device should be prevented from being shown to user.
+
+## Decision
+
+To protect project goals and to provide clarity to our users and contributors,
+we’re introducing the following rules on how discoverable integrations need to be configured:
+
+- Integrations that are discoverable must provide an unique id (via `async_set_unique_id`) to allow the user to ignore the discovered config entry.
+
+These rules apply to all new integrations. Existing integrations should be reviewed for possible ways to improve identification during discovery.
+
+## Consequences
+
+Discovery UX improves at the expense of some unidentifiable or non-conforming devices requiring manual setup.

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -12,7 +12,7 @@ There is a mechanism to ignore discovered config flows using unique ids attached
 but not all integrations may set an unique id due to lack of truly unique identifiers
 or just not having been updated for concerns of backward compatibility.
 
-This creates an UX issue that has started to become more pronounced with more config flows
+This creates a UX issue that has started to become more pronounced with more config flows
 being added every release (which is awesome!). The real issue is that not all discovery processes 
 are created equal and that becomes an issue for consistency.
 

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -18,7 +18,7 @@ are created equal and that becomes an issue for consistency.
 
 ## Proposal
 
-All new integratons with discoverable config flows should be required to set an
+All new integrations with discoverable config flows should be required to set a
 unique id during discovery.
 
 All existing integrations with discoverable config flows should be reviewed for

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -25,8 +25,8 @@ All existing integrations with discoverable config flows should be reviewed for
 possible ways to improve identification during discovery. A whitelist could be developed
 to allow existing integrations to remain functional under new requirements.
 
-If an unique id can sometimes not be available such as older devices that lack unique identifiers
-in zeroconf/ssdp/api/etc then the config entry should not be shown to user.
+If a unique id can not be made available, such as on older devices that lack unique identifiers
+in zeroconf/SSDP/API/etc, then the config entry should not be shown to the user.
 
 ## Decision
 

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -41,6 +41,5 @@ for possible ways to improve identification during discovery.
 
 ## Consequences
 
-- Removes confusion and questions around the ability to ignore unwanted discoveries
-  for all users.
+- Removes confusion and questions around the ability to ignore unwanted discoveries.
 - This might impact the number of integrations that are able to be discovered.

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -21,9 +21,9 @@ are created equal and that becomes an issue for consistency.
 All future integratons with discoverable config flows should be required to set an
 unique id during discovery.
 
-All existing integrations should be reviewed for possible ways to improve identification
-during discovery config flow. A whitelist could be developed to allow existing integrations
-to remain functional under new requirements.
+All existing integrations with discoverable config flows should be reviewed for
+possible ways to improve identification  during discovery. A whitelist could be developed
+to allow existing integrations to remain functional under new requirements.
 
 If a unique id can sometimes not be available such as older devices lack identifiers in 
 zeroconf/ssdp/etc then the device should be prevented from being shown to user.

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -13,7 +13,7 @@ but not all integrations may set an unique id due to lack of truly unique identi
 or just not having been updated for concerns of backward compatibility.
 
 This creates an UX issue that has started to become more pronounced with more config flows
-being added every release (which is awesome!). The real issue is not all discovery processes 
+being added every release (which is awesome!). The real issue is that not all discovery processes 
 are created equal and that becomes an issue for consistency.
 
 ## Proposal

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -18,7 +18,7 @@ are created equal and that becomes an issue for consistency.
 
 ## Proposal
 
-All future integratons with discoverable config flows should be required to set an
+All new integratons with discoverable config flows should be required to set an
 unique id during discovery.
 
 All existing integrations with discoverable config flows should be reviewed for

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -10,7 +10,7 @@ Accepted
 
 There is a mechanism to ignore discovered config flows using unique ids attached to config flow
 but not all integrations may set an unique id due to lack of truly unique identifiers
-or just not having been updated for concerns of backwards compatibility.
+or just not having been updated for concerns of backward compatibility.
 
 This creates an UX issue that has started to become more pronounced with more config flows
 being added every release (which is awesome!). The real issue is not all discovery processes 

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -9,7 +9,7 @@ Accepted
 ## Context
 
 There is a mechanism to ignore discovered config flows using unique ids attached to config flow
-but not all integrations may set a unique id due to lack of truly unique identifiers
+but not all integrations may set an unique id due to lack of truly unique identifiers
 or just not having been updated for concerns of backwards compatibility.
 
 This creates an UX issue that has started to become more pronounced with more config flows

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -30,10 +30,7 @@ in zeroconf/SSDP/API/etc, then the config entry should not be shown to the user.
 
 ## Decision
 
-To protect project goals and to provide clarity to our users and contributors,
-we're introducing the following rules on how discoverable integrations need to be designed:
-
-- Integrations that are discoverable must provide an unique id (via `async_set_unique_id`) 
+Integrations that are discoverable must provide an unique id (via `async_set_unique_id`) 
 to allow the user to ignore the discovered config entry.
 
 These rules apply to all new integrations. Existing integrations should be reviewed 

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -31,7 +31,7 @@ in zeroconf/SSDP/API/etc, then the config entry should not be shown to the user.
 
 ## Decision
 
-Integrations that are discoverable must provide an unique id (via `async_set_unique_id`) 
+Integrations that are discoverable must provide a unique id (via `async_set_unique_id`) 
 to allow the user to ignore the discovered config entry.
 
 These rules apply to all new integrations. Existing integrations should be reviewed 

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -8,9 +8,10 @@ Accepted
 
 ## Context
 
-There is a mechanism to ignore discovered config flows using unique ids attached to config flow
-but not all integrations may set an unique id due to lack of truly unique identifiers
-or just not having been updated for concerns of backward compatibility.
+There is a mechanism to ignore discovered config flows using unique ids
+attached to config entries but not all integrations may set an unique id
+due to lack of truly unique identifiers or just not having been updated for
+concerns of backward compatibility.
 
 This creates a UX issue that has started to become more pronounced with more config flows
 being added every release (which is awesome!). The real issue is that not all discovery processes 

--- a/adr/0011-discovery-requires-unique-id.md
+++ b/adr/0011-discovery-requires-unique-id.md
@@ -22,11 +22,11 @@ All future integratons with discoverable config flows should be required to set 
 unique id during discovery.
 
 All existing integrations with discoverable config flows should be reviewed for
-possible ways to improve identification  during discovery. A whitelist could be developed
+possible ways to improve identification during discovery. A whitelist could be developed
 to allow existing integrations to remain functional under new requirements.
 
-If a unique id can sometimes not be available such as older devices lack identifiers in 
-zeroconf/ssdp/etc then the device should be prevented from being shown to user.
+If an unique id can sometimes not be available such as older devices that lack unique identifiers
+in zeroconf/ssdp/api/etc then the config entry should not be shown to user.
 
 ## Decision
 


### PR DESCRIPTION
To protect project goals and to provide clarity to our users and contributors,
we're introducing the following rules on how discoverable integrations need to be designed:

- Integrations that are discoverable must provide an unique id (via `async_set_unique_id`) 
to allow the user to ignore the discovered config entry.

These rules apply to all new integrations. Existing integrations should be reviewed 
for possible ways to improve identification during discovery.