### PR TITLE
Adjust required version of NetworkManager

### DIFF
--- a/adr/0014-home-assistant-supervised.md
+++ b/adr/0014-home-assistant-supervised.md
@@ -24,7 +24,7 @@ Docker CE (Community Edition) is the only supported containerization method for 
 
 - Docker CE >= 19.03
 - Systemd >= 239
-- NetworkManager >= 1.18.0
+- NetworkManager >= 1.14.6
 - Avahi >= 0.7
 - AppArmor == 2.13.x (built into the kernel)
 - Debian Linux Debian 10 aka Buster (no derivatives)


### PR DESCRIPTION
Changes the required version of NetworkManager to match that available in Debian 10 (buster), since 1.18.0 is not. Since supervisor reports no errors running with 1.14.6, this should be a harmless change, and eliminates confusion in diagnosing such errors, as seen here - https://community.home-assistant.io/t/networkmanager-1-18-0-on-debian-buster/223968 - and in issue #427 .