### PR TITLE
Remove Avahi

### DIFF
--- a/adr/0014-home-assistant-supervised.md
+++ b/adr/0014-home-assistant-supervised.md
@@ -25,7 +25,6 @@ Docker CE (Community Edition) is the only supported containerization method for 
 - Docker CE >= 19.03
 - Systemd >= 239
 - NetworkManager >= 1.14.6
-- Avahi >= 0.7
 - AppArmor == 2.13.x (built into the kernel)
 - Debian Linux Debian 10 aka Buster (no derivatives)
 


### PR DESCRIPTION

Future of https://github.com/home-assistant/supervised-installer/pull/126

Is not needed with new NetworkManager settings and Supervisor. Maybe next year we can inform people if they not use systemd-resolvd (default) on Debian.