### PR TITLE
Amend ADR004 to allow extracting forms during the auth phase

### DIFF
--- a/adr/0004-webscraping.md
+++ b/adr/0004-webscraping.md
@@ -1,5 +1,4 @@
 # 4. Webscraping
-gs
 Date: 2019-06-27
 
 Architecture issue: [#252](https://github.com/home-assistant/architecture/issues/252)

--- a/adr/0004-webscraping.md
+++ b/adr/0004-webscraping.md
@@ -4,6 +4,10 @@ Date: 2019-06-27
 
 Architecture issue: [#252](https://github.com/home-assistant/architecture/issues/252)
 
+Changelog:
+ - 2019-06-27 Initial version accepted
+ - 2021-02-09 Amendment to add exception for authentication phase
+
 ## Status
 
 Accepted

--- a/adr/0004-webscraping.md
+++ b/adr/0004-webscraping.md
@@ -27,9 +27,10 @@ Webscraping comes with the following downsides:
 - We no longer accept any new integration that relies on webscraping
 - We identify, deprecate for 2 releases and remove integrations that rely on webscraping
 - It will still be possible to have custom integrations provide information via webscraping
-- Generic integration to parse HTML are excluded from this decision
 
-### Exception
+### Exceptions
+
+Generic integrations to parse HTML are excluded from this decision.
 
 An exception is made for the authentication phase. An integration is allowed to extract fields from forms. To make it more robust, data should not be gathered by scraping individual fields but instead scrape all fields at once.
 

--- a/adr/0004-webscraping.md
+++ b/adr/0004-webscraping.md
@@ -1,5 +1,5 @@
 # 4. Webscraping
-
+gs
 Date: 2019-06-27
 
 Architecture issue: [#252](https://github.com/home-assistant/architecture/issues/252)
@@ -24,6 +24,10 @@ Webscraping comes with the following downsides:
 - We identify, deprecate for 2 releases and remove integrations that rely on webscraping
 - It will still be possible to have custom integrations provide information via webscraping
 - Generic integration to parse HTML are excluded from this decision
+
+### Exception
+
+An exception is made for the authentication phase. An integration is allowed to extract fields from forms. To make it more robust, data should not be gathered by scraping individual fields but instead scrape all fields at once.
 
 ## Consequences
 

--- a/adr/0004-webscraping.md
+++ b/adr/0004-webscraping.md
@@ -1,4 +1,5 @@
 # 4. Webscraping
+
 Date: 2019-06-27
 
 Architecture issue: [#252](https://github.com/home-assistant/architecture/issues/252)


### PR DESCRIPTION
We've seen more and more integrations struggle with ADR004. The problem they struggle with is not that the data fetching is based on scraping, but that some parts of the authentication flow requires extraction of the form fields and their values. Fetching data should happen via an API. We will be more flexible, and hinder less integrations, if we allow integrations to extract forms during the authentication flow. 

That's why I want to propose that we amend ADR004 to allow web scraping of forms during the authentication phase. For robustness, integrations should fetch all fields of the form and not individually extract values of fields in the form. These are less likely to change.

Please limit discussion in this PR to this change. Discussing the ADR004 or other amendments is out of scope for this PR. Start a discussion topic instead.