### PR TITLE
Fix broken link to dev docs.

### DIFF
--- a/adr/0003-monitor-condition-and-data-selectors.md
+++ b/adr/0003-monitor-condition-and-data-selectors.md
@@ -27,7 +27,7 @@ Layer model:
   -------------      ---------      ------------
 ```
 
-Integrations can set the `entity_registry_enabled_default` property on their entity objects to instruct Home Assistant to disable certain entities by default ([docs](https://developers.home-assistant.io/docs/en/entity_index.html#advanced-properties)).
+Integrations can set the `entity_registry_enabled_default` property on their entity objects to instruct Home Assistant to disable certain entities by default ([docs](https://developers.home-assistant.io/docs/entity_registry_disabled_by/#integrations-setting-default-value-of-disabled_by-for-new-entity-registry-entries)).
 
 ## Consequences
 


### PR DESCRIPTION
Current link points to outdated developers doc location.

I pointed to the subsection specifically about `entity_registry_enabled_default`, but we could also consider just pointing to the whole page.  It would be less specific to point to the whole page, but more robust to changes in the structure within the page.