### PR TITLE
Change guidance from issue to discussion in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Repo to discuss Home Assistant architecture
 
-- For each topic you want to discuss, create a new issue [here](https://github.com/home-assistant/architecture/issues/new)
+- For each topic you want to discuss, create a new discussion [here](https://github.com/home-assistant/architecture/discussions/new)
 - Please do not go off-topic, create a new topic instead.
 - If a decision is made, it is recorded as an Architecture Decision Record and stored in [the ADR folder](https://github.com/home-assistant/architecture/blob/master/adr/).


### PR DESCRIPTION
Not sure if `Discussions` is here to stay, but for now it would be good to change this link in the readme. Since the link is directly to the new issue page, you won't see the pinned issue (https://github.com/home-assistant/architecture/issues/496).