### PR TITLE
Update Supervised supported OS

### DIFF
--- a/adr/0014-home-assistant-supervised.md
+++ b/adr/0014-home-assistant-supervised.md
@@ -26,7 +26,7 @@ Docker CE (Community Edition) is the only supported containerization method for 
 - Systemd >= 239
 - NetworkManager >= 1.14.6
 - AppArmor == 2.13.x (built into the kernel)
-- Debian Linux Debian 10 aka Buster (no derivatives)
+- Debian Linux Debian 11 aka Bullseye (no derivatives)
 - [Home Assistant OS-Agent](https://github.com/home-assistant/os-agent) (Only the [latest release](https://github.com/home-assistant/os-agent/releases/latest) is supported)
 
 Only the above-listed version of Debian Linux is supported for running this installation method. When a new major version of Debian is released, the previous major version is dropped, with a deprecation time of 4 months. An exception to this rule occurs if the new version does not meet the requirements of the Supervisor.

--- a/adr/0014-home-assistant-supervised.md
+++ b/adr/0014-home-assistant-supervised.md
@@ -46,7 +46,7 @@ In case any abnormality is detected that prevents Home Assistant from functionin
 ### Required Expertise
 
 - **Installation**
-  The user first needs to install Debian 10 and make sure all the required components are installed and are the correct version. They then need to run the installer script.
+  The user first needs to install Debian and make sure all the required components are installed and are the correct version. They then need to run the installer script.
 
 - **Start when the system is started:** done by the installer
 - **Run with full network access:** done by the installer
@@ -65,7 +65,7 @@ In case any abnormality is detected that prevents Home Assistant from functionin
   - **Security updates for OS:** Responsibility of the user.
   - **Maintaining the components required for the Supervisor:** Responsibility of the user. Over time as Supervisor requirements change, you might have to upgrade your OS to be able to use the required version.
 
-**Conclusion:** Expert. Maintaining a Debian 10 installation to a very specific set of requirements is hard.
+**Conclusion:** Expert. Maintaining a Debian installation to a very specific set of requirements is hard.
 
 ## Consequences
 


### PR DESCRIPTION
Updates the ADR that lists the requirements for Home Assistant Supervised installations.

Marks Debian 11 supported, removes Debian 10 as it is deprecated to keep documentation current and reflect what users should be running.

ℹ️  This PR correctly targets the `current` branch, as the Supervisor is released independently of Home Assistant Core.
⚠️ Should not be merged until the related Supervisor is released to stable

After the deprecation period for Debian 10 has been passed, we can look at bumping other dependencies to have a higher minimum requirement.

Supervisor PR: https://github.com/home-assistant/supervisor/pull/3066