### PR TITLE
Remove broken link in translations adr

### DIFF
--- a/adr/0009-translations-2.0.md
+++ b/adr/0009-translations-2.0.md
@@ -10,7 +10,7 @@ Accepted
 
 The backend has only one API endpoint to fetch translations: `frontend/get_translations`. It takes no parameters. This needs to load all relevant translations. Because of config flows, relevant translations are all translations of all our currently loaded integrations PLUS any integration that has a config flow.
 
-With so many integrations with config flows, this API call is getting huge. On current dev, the response is 142KB! ([truncated example](https://hastebin.com/raw/aturojejez))
+With so many integrations with config flows, this API call is getting huge. On current dev, the response is 142KB!
 
 Our main translation files (`strings.json`) is keyed by "area" where they are used. There is:
 - `config` for config flow


### PR DESCRIPTION
Link is not working any more because hastebin has been aquired by toptal.com.

I think it is okay to just remove it as it is not neccessary to understand the ADR.

If you think it *is* needed, an example of the old API call would need to be hosted on a more reliable url (maybe in this repo?).