### PR TITLE
0019 GPIO: Spelling consistency plus final approval date correction

### DIFF
--- a/adr/0019-GPIO.md
+++ b/adr/0019-GPIO.md
@@ -1,6 +1,6 @@
 # 0019. GPIO
 
-Date: 2021-12-14
+Date: 2021-12-20
 
 ## Status
 
@@ -8,7 +8,7 @@ Accepted
 
 ## Context
 
-We currently have a lot of integrations that use or are based on GPIO (including SPI and i2c busses).
+We currently have a lot of integrations that use or are based on GPIO (including SPI and I2C busses).
 
 - All of these integrations have a low usage count (source Home Assistant Analytics),
   but add the same amount of maintenance and review time to the core.


### PR DESCRIPTION
There were two inconsistent spellings of "I2C". Plus shouldn't the date be today as this ADR was approved and merged today?