### PR TITLE
Update Python version requirements

### DIFF
--- a/adr/0002-minimum-supported-python-version.md
+++ b/adr/0002-minimum-supported-python-version.md
@@ -1,6 +1,6 @@
 # 2. Minimum supported Python version
 
-Date: 2019-05-13, updated 2023-02-05 (python version clarification)
+Date: 2019-05-13, updated 2023-02-05 (Python version clarification)
 
 Architecture issue: [#167](https://github.com/home-assistant/architecture/issues/167), [#278](https://github.com/home-assistant/architecture/issues/278)
 
@@ -10,11 +10,11 @@ Accepted
 
 ## Context
 
-Home Assistant currently sets the minimum Python requirement to the penultimate minor Python version released upstream. We do not specifically try to support the Python version used in Debian Stable.
+Home Assistant currently sets the minimum Python requirement to the penultimate minor Python version released upstream.
 
 ## Decision
 
-Home Assistant will try to support the latest two released minor upstream Python versions. For example, currently we will support Python 3.10 and would like to support Python 3.11. Python 3.9 is no longer supported at this point.
+Home Assistant will try to support the latest two released minor upstream Python versions. For example, if the current latest version is 3.11, we will support Python 3.10 and would like to support Python 3.11; however, Python 3.9 is no longer supported at this point.
 
 Once a new minor Python version is released, the to be dropped minor version will be deprecated for a period of 2 months, after which it will be removed. While deprecated, Home Assistant will print a warning message to inform the user.
 
@@ -25,4 +25,4 @@ Supported micro versions are decided on minor version basis, and codified in the
 - June 1, 2019: Deprecate Python 3.5
 - August 1, 2019: Adopt that Home Assistant will support the latest 2 minor releases of Python. This means that we drop support for Python 3.5.
 
-We have three installation methods. Both Hass.io and Docker are already using the latest Python version.
+We have three installation methods that are based on Docker containers (Home Assistant OS, Container, and Supervised), which are maintained and kept up to date by the Home Assistant project.

--- a/adr/0002-minimum-supported-python-version.md
+++ b/adr/0002-minimum-supported-python-version.md
@@ -1,6 +1,6 @@
 # 2. Minimum supported Python version
 
-Date: 2019-05-13, updated 2019-09-02 (micro version clarification)
+Date: 2019-05-13, updated 2023-02-05 (python version clarification)
 
 Architecture issue: [#167](https://github.com/home-assistant/architecture/issues/167), [#278](https://github.com/home-assistant/architecture/issues/278)
 
@@ -10,11 +10,11 @@ Accepted
 
 ## Context
 
-Home Assistant currently sets the minimum Python requirement to whatever is shipped in Debian Stable. As most installations are now based on Docker, it is easier to upgrade.
+Home Assistant currently sets the minimum Python requirement to the penultimate minor Python version released upstream. We do not specifically try to support the Python version used in Debian Stable.
 
 ## Decision
 
-Home Assistant will support the latest two released minor Python versions. For example, currently we will support Python 3.6 and Python 3.7. Once Python 3.8 is released, we will support only Python 3.7 and Python 3.8.
+Home Assistant will try to support the latest two released minor upstream Python versions. For example, currently we will support Python 3.10 and would like to support Python 3.11. Python 3.9 is no longer supported at this point.
 
 Once a new minor Python version is released, the to be dropped minor version will be deprecated for a period of 2 months, after which it will be removed. While deprecated, Home Assistant will print a warning message to inform the user.
 
@@ -25,4 +25,4 @@ Supported micro versions are decided on minor version basis, and codified in the
 - June 1, 2019: Deprecate Python 3.5
 - August 1, 2019: Adopt that Home Assistant will support the latest 2 minor releases of Python. This means that we drop support for Python 3.5.
 
-We have three installation methods. Both Hass.io and Docker are already using the latest Python version. The next Debian Stable will ship with Python 3.7, so Hassbian users might not need to do anything besides updating their distro.
+We have three installation methods. Both Hass.io and Docker are already using the latest Python version.


### PR DESCRIPTION
Clarifies Python version requirements as per the discussion in home-assistant/core#86807

We try to support latest 2 python versions.