### PR TITLE
Update ADR to support Debian 12 Bookworm

### DIFF
--- a/adr/0014-home-assistant-supervised.md
+++ b/adr/0014-home-assistant-supervised.md
@@ -27,7 +27,7 @@ Docker CE (Community Edition) is the only supported containerization method for 
 - NetworkManager >= 1.14.6
 - udisks2 >= 2.8
 - AppArmor == 2.13.x (built into the kernel)
-- Debian Linux Debian 11 aka Bullseye (no derivatives)
+- Debian Linux Debian 12 aka Bookworm (no derivatives)
 - [Home Assistant OS-Agent](https://github.com/home-assistant/os-agent) (Only the [latest release](https://github.com/home-assistant/os-agent/releases/latest) is supported)
 
 Only the above-listed version of Debian Linux is supported for running this installation method. When a new major version of Debian is released, the previous major version is dropped, with a deprecation time of 4 months. An exception to this rule occurs if the new version does not meet the requirements of the Supervisor.


### PR DESCRIPTION
For now I have removed Debian Bullseye and added Bookworm as it is already implied the Bullseye is still supported for 4 months, Although I am not sure if I should add both 
Link to Supervisor PR: https://github.com/home-assistant/supervisor/pull/4377
Link to Supervised Installer PR: https://github.com/home-assistant/supervised-installer/pull/297