### PR TITLE
Update minimum supported SQLite version to 3.40.1

### DIFF
--- a/adr/0018-supported-databases.md
+++ b/adr/0018-supported-databases.md
@@ -38,7 +38,7 @@ Limit DB support to the following:
 - MariaDB ≥ 10.3 (2017)
 - MySQL ≥ 8.0 (2018)
 - PostgreSQL ≥ 12 (2019)
-- SQLite ≥ 3.31.0 (2020)
+- SQLite ≥ 3.40.1 (2022)
 
 Start to emit warnings about unsupported databases in Home Assistant 2021.11, the recorder will fail
 to start with Home Assistant 2022.2.


### PR DESCRIPTION
Since we do not test against older versions of SQLite, they are a terrible user experience, and we keep [finding problems](https://github.com/home-assistant/core/pull/104296)

Update the minimum SQLite version to 3.40.1 which is the bookworm version

core PR proposes 2025.2 as the removal date for the old version https://github.com/home-assistant/core/pull/104298 