### PR TITLE
Update ADR-0015: sync list of supported targets with reality

### DIFF
--- a/adr/0015-home-assistant-os.md
+++ b/adr/0015-home-assistant-os.md
@@ -18,20 +18,23 @@ This is the generally recommended installation method and the one that our websi
 
 ### Supported boards/hardware/machines
 
-- Home Assistant Yellow
+- Home Assistant Yellow (with CM4 and CM5 modules)
 - Home Assistant Green
 - Raspberry Pi 3 Model B and B+ 32-bit
 - Raspberry Pi 3 Model B and B+ 64-bit
 - Raspberry Pi 4 Model B 32-bit
 - Raspberry Pi 4 Model B 64-bit
-- Tinkerboard
+- Raspberry Pi 5 Model B 64-bit
+- ASUS Tinker Board
+- ASUS Tinker Board S
 - ODROID-C2
 - ODROID-C4
-- ODROID-N2
+- ODROID-N2/N2+
 - ODROID-M1
+- ODROID-M1S
 - ODROID-XU4
-- Bare-metal on x86-64 PCs (e.g. Intel NUC, via `generic-x86-64` image)
-- Virtual Machine (x86-64/AMD64 based by `ova` image)
+- Bare-metal on x86-64 PCs (e.g. Intel NUC, via `generic-x86-64` image) on best effort basis (i.e. not all x86-64 machines are guaranteed to be supported fully)
+- Virtual Machine (x86-64/AMD64-based by `ova` image, AArch64/ARM64-based by `generic-aarch64` image)
 
 ### Supported Operating Systems and versions
 

--- a/adr/0015-home-assistant-os.md
+++ b/adr/0015-home-assistant-os.md
@@ -2,6 +2,9 @@
 
 Date: 2020-06-08
 
+Changelog:
+ - 2025-01-23 Updated the list of hardware whose support was added in the meantime
+
 ## Status
 
 Accepted


### PR DESCRIPTION
Updating the outdated list of targets to current state which the support stabilized at without any prior architecture discussion.

Commenting on individual changes:

 - On Yellow we rolled out official support for CM5 in HAOS 14. There was no architecture discussion on this and we should keep it in mind for the future. This is just reflecting the current state.
 - Similar for RPi 5 - we started to support it without any change here.
 - "Tinkerboard" was too vague, we don't support all models, so clarifying on the actual models currently supported.
 - N2+ is just a variation of N2, N2 is discontinued but can be interchanged easily with only a difference in the device tree. Explicitly adding also the N2+ to avoid confusion.
 - ODROID-M1S is officially supported for a while through a community addition. Unlike N2 vs. N2+, it's entirely different HW, so it deserves an extra line.
 - For x86, we need to state that not all hardware combinations can be fully supported - although the status quo is that the support is done on "best effort basis", we need to communicate it publicly too.
 - There was no mention of generic-aarch64 image. Although it can be targeted at many different boards, OS maintainers can't guarantee official support on any hardware. That's why the mention was added only to the VM line.

I am intentionally ignoring the presence of RPi 2 target in our builds. Support for that was probably never communicated publicly, this document neither the docs mention it and it's way too underspec'd for the current demands. These facts will eventually make it easier to drop it from our builds.