### PR TITLE
Update ADR-0015: add already supported Khadas VIM3 to the list

### DIFF
--- a/adr/0015-home-assistant-os.md
+++ b/adr/0015-home-assistant-os.md
@@ -4,6 +4,7 @@ Date: 2020-06-08
 
 Changelog:
  - 2025-01-23 Updated the list of hardware whose support was added in the meantime
+ - 2025-09-29 Added Khadas VIM3 which was unintentionally left out in the previous update
 
 ## Status
 
@@ -30,6 +31,7 @@ This is the generally recommended installation method and the one that our websi
 - Raspberry Pi 5 Model B 64-bit
 - ASUS Tinker Board
 - ASUS Tinker Board S
+- Khadas VIM3
 - ODROID-C2
 - ODROID-C4
 - ODROID-N2/N2+


### PR DESCRIPTION
In #1189 Khadas VIM3 was unintentionally left out from the list of supported boards. Its support was added and maintained since home-assistant/operating-system#1473, so this is just another sync with the reality.