### PR TITLE
Revert ADR-0016: drop Home Assistant Core as supported installation method

### DIFF
--- a/adr/0016-home-assistant-core.md
+++ b/adr/0016-home-assistant-core.md
@@ -4,7 +4,10 @@ Date: 2020-07-01
 
 ## Status
 
-Accepted
+Reverted by [discussion #1197](https://github.com/home-assistant/architecture/discussions/1197).
+
+Home Assistant Core is no longer an officially supported installation method.
+Users are encouraged to migrate to Home Assistant OS or Home Assistant Container.
 
 ## Context
 


### PR DESCRIPTION
Per approved discussion #1197, mark ADR-0016 as reverted.